### PR TITLE
Maintain directory context when upgrading

### DIFF
--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -12,9 +12,13 @@ alias ohmyzsh="st ~/.oh-my-zsh"
 DISABLE_AUTO_UPDATE="true"
 
 upgrade_dotfiles() {
+  if [[ `pwd` == $HOME/.dotfiles ]] ; then
+    ./update.sh
+  else
     pushd ~/.dotfiles > /dev/null
     ./update.sh
     popd > /dev/null
+  fi
 }
 
 # for the over eager upgrade junky


### PR DESCRIPTION
If you're in your `~/.dotfiles` directory and run `upgrade_dotfiles` you'll find yourself in a different directory when the command completes. This is because `pushd <whatever directory you're already in>` is a no-op but `popd` still runs.